### PR TITLE
feat: add option to start on Monday (#18)

### DIFF
--- a/src/js/calendar/body.js
+++ b/src/js/calendar/body.js
@@ -38,7 +38,7 @@ var Body = defineClass(
        * @type {DateLayer}
        * @private
        */
-      this._dateLayer = new DateLayer(language);
+      this._dateLayer = new DateLayer(language, option);
 
       /**
        * MonthLayer

--- a/src/js/calendar/body.js
+++ b/src/js/calendar/body.js
@@ -23,8 +23,9 @@ var TYPE_YEAR = constants.TYPE_YEAR;
  */
 var Body = defineClass(
   /** @lends Body.prototype */ {
-    init: function(bodyContainer, option) {
-      var language = option.language;
+    init: function(bodyContainer, options) {
+      var language = options.language;
+      var weekStartDay = options.weekStartDay;
 
       /**
        * Body container element
@@ -38,7 +39,7 @@ var Body = defineClass(
        * @type {DateLayer}
        * @private
        */
-      this._dateLayer = new DateLayer(language, option);
+      this._dateLayer = new DateLayer(language, weekStartDay);
 
       /**
        * MonthLayer

--- a/src/js/calendar/index.js
+++ b/src/js/calendar/index.js
@@ -20,6 +20,7 @@ var constants = require('../constants');
 var dateUtil = require('../dateUtil');
 var util = require('../util');
 
+var DEFAULT_WEEK_START_DAY = constants.DEFAULT_WEEK_START_DAY;
 var DEFAULT_LANGUAGE_TYPE = constants.DEFAULT_LANGUAGE_TYPE;
 
 var TYPE_DATE = constants.TYPE_DATE;
@@ -90,7 +91,7 @@ var Calendar = defineClass(
           date: new Date(),
           type: TYPE_DATE,
           usageStatistics: true,
-          weekStartDay: 'Sun'
+          weekStartDay: DEFAULT_WEEK_START_DAY
         },
         options
       );

--- a/src/js/calendar/index.js
+++ b/src/js/calendar/index.js
@@ -62,7 +62,8 @@ var BODY_SELECTOR = '.tui-calendar-body';
  *     showToday: true,
  *     showJumpButtons: false,
  *     date: new Date(),
- *     type: 'date'
+ *     type: 'date',
+ *     weekStart: 1,
  * });
  *
  * calendar.on('draw', function(event) {

--- a/src/js/calendar/index.js
+++ b/src/js/calendar/index.js
@@ -51,7 +51,7 @@ var BODY_SELECTOR = '.tui-calendar-body';
  *     @param {boolean} [options.showToday = true] - Show today.
  *     @param {boolean} [options.showJumpButtons = false] - Show the yearly jump buttons (move to the previous and next year in 'date' Calendar)
  *     @param {boolean} [options.usageStatistics = true] - Send a hostname to Google Analytics (default: true)
- *     @param {boolean} [options.weekStart = 0] - Day of the week start. 0 (Sunday) to 6 (Saturday) (default: 0(start on Sunday))
+ *     @param {string} [options.weekStartDay = 'Sun'] - Start of the week. 'Sun', 'Mon', ..., 'Sat'(default: 'Sun'(start on Sunday))
  * @example
  * import DatePicker from 'tui-date-picker' // ES6
  * // const DatePicker = require('tui-date-picker'); // CommonJS
@@ -63,7 +63,7 @@ var BODY_SELECTOR = '.tui-calendar-body';
  *     showJumpButtons: false,
  *     date: new Date(),
  *     type: 'date',
- *     weekStart: 1,
+ *     weekStartDay: 'Mon',
  * });
  *
  * calendar.on('draw', function(event) {
@@ -90,7 +90,7 @@ var Calendar = defineClass(
           date: new Date(),
           type: TYPE_DATE,
           usageStatistics: true,
-          weekStart: 0
+          weekStartDay: 'Sun'
         },
         options
       );

--- a/src/js/calendar/index.js
+++ b/src/js/calendar/index.js
@@ -51,7 +51,7 @@ var BODY_SELECTOR = '.tui-calendar-body';
  *     @param {boolean} [options.showToday = true] - Show today.
  *     @param {boolean} [options.showJumpButtons = false] - Show the yearly jump buttons (move to the previous and next year in 'date' Calendar)
  *     @param {boolean} [options.usageStatistics = true] - Send a hostname to Google Analytics (default: true)
- *     @param {boolean} [options.startOnMonday = false] - show the date starting on Monday (default: false(start on Sunday))
+ *     @param {boolean} [options.weekStart = 0] - Day of the week start. 0 (Sunday) to 6 (Saturday) (default: 0(start on Sunday))
  * @example
  * import DatePicker from 'tui-date-picker' // ES6
  * // const DatePicker = require('tui-date-picker'); // CommonJS
@@ -89,7 +89,7 @@ var Calendar = defineClass(
           date: new Date(),
           type: TYPE_DATE,
           usageStatistics: true,
-          startOnMonday: false
+          weekStart: 0
         },
         options
       );

--- a/src/js/calendar/index.js
+++ b/src/js/calendar/index.js
@@ -51,6 +51,7 @@ var BODY_SELECTOR = '.tui-calendar-body';
  *     @param {boolean} [options.showToday = true] - Show today.
  *     @param {boolean} [options.showJumpButtons = false] - Show the yearly jump buttons (move to the previous and next year in 'date' Calendar)
  *     @param {boolean} [options.usageStatistics = true] - Send a hostname to Google Analytics (default: true)
+ *     @param {boolean} [options.startOnMonday = false] - show the date starting on Monday (default: false(start on Sunday))
  * @example
  * import DatePicker from 'tui-date-picker' // ES6
  * // const DatePicker = require('tui-date-picker'); // CommonJS
@@ -87,7 +88,8 @@ var Calendar = defineClass(
           showJumpButtons: false,
           date: new Date(),
           type: TYPE_DATE,
-          usageStatistics: true
+          usageStatistics: true,
+          startOnMonday: false
         },
         options
       );

--- a/src/js/calendar/layerBody/date.js
+++ b/src/js/calendar/layerBody/date.js
@@ -11,18 +11,10 @@ var dateUtil = require('../../dateUtil');
 var bodyTmpl = require('./../../../template/calendar/dateLayer');
 var LayerBase = require('./base');
 var TYPE_DATE = require('../../constants').TYPE_DATE;
+var WEEK_START_DAY_MAP = require('../../constants').WEEK_START_DAY_MAP;
 
 var DATE_SELECTOR = '.tui-calendar-date';
 var DAYS_OF_WEEK = 7;
-var WEEK_START_DAY_MAP = {
-  sun: 0,
-  mon: 1,
-  tue: 2,
-  wed: 3,
-  thu: 4,
-  fri: 5,
-  sat: 6
-};
 
 /**
  * @ignore
@@ -103,7 +95,7 @@ var DateLayer = defineClass(
 
         week = this._getWeek(year, month, dates);
 
-        if (this.weekStartDay && !this._isFirstWeek(weekNumber, week[0].dayInMonth)) {
+        if (this.weekStartDay && !_isFirstWeek(weekNumber, week[0].dayInMonth)) {
           weeks.push(this._getFirstWeek(year, month));
           weeksCount -= 1; // Fix for no changing height
         }
@@ -180,10 +172,6 @@ var DateLayer = defineClass(
       return this._element.querySelectorAll(DATE_SELECTOR);
     },
 
-    _isFirstWeek: function(weekIndex, dayInMonth) {
-      return weekIndex || dayInMonth === 1 || dayInMonth > DAYS_OF_WEEK;
-    },
-
     _getFirstWeek: function(year, month) {
       var firstWeekDates = [];
       var i;
@@ -196,5 +184,9 @@ var DateLayer = defineClass(
     }
   }
 );
+
+function _isFirstWeek(weekIndex, dayInMonth) {
+  return weekIndex || dayInMonth === 1 || dayInMonth > DAYS_OF_WEEK;
+}
 
 module.exports = DateLayer;

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -22,5 +22,16 @@ module.exports = {
   CLASS_NAME_PREV_MONTH_BTN: 'tui-calendar-btn-prev-month',
   CLASS_NAME_PREV_YEAR_BTN: 'tui-calendar-btn-prev-year',
   CLASS_NAME_NEXT_YEAR_BTN: 'tui-calendar-btn-next-year',
-  CLASS_NAME_NEXT_MONTH_BTN: 'tui-calendar-btn-next-month'
+  CLASS_NAME_NEXT_MONTH_BTN: 'tui-calendar-btn-next-month',
+
+  DEFAULT_WEEK_START_DAY: 'Sun',
+  WEEK_START_DAY_MAP: {
+    sun: 0,
+    mon: 1,
+    tue: 2,
+    wed: 3,
+    thu: 4,
+    fri: 5,
+    sat: 6
+  }
 };

--- a/src/js/dateRangePicker/index.js
+++ b/src/js/dateRangePicker/index.js
@@ -32,10 +32,12 @@ var CLASS_NAME_SELECTED_RANGE = 'tui-is-selected-range';
  *         @param {HTMLElement|string} options.startpicker.input - Startpicker input element or selector
  *         @param {HTMLElement|string} options.startpicker.container - Startpicker container element or selector
  *         @param {Date|number} [options.startpicker.date] - Initial date of the start picker. Set by a Date instance or a number(timestamp). (default: no initial date)
+ *         @param {number} [options.startpicker.weekStart = 0] - start picker's day of the week start. 0 (Sunday) to 6 (Saturday) (default: 0(start on Sunday))
  *     @param {object} options.endpicker - Endpicker options
  *         @param {HTMLElement|string} options.endpicker.input - Endpicker input element or selector
  *         @param {HTMLElement|string} options.endpicker.container - Endpicker container element or selector
  *         @param {Date|number} [options.endpicker.date] - Initial date of the end picker. Set by a Date instance or a number(timestamp). (default: no initial date)
+ *         @param {number} [options.endpicker.weekStart = 0] - end picker's day of the week start. 0 (Sunday) to 6 (Saturday) (default: 0(start on Sunday))
  *     @param {('date'|'month'|'year')} [options.type = 'date'] - DatePicker type. Determine whether to choose a date, month, or year.
  *     @param {string} [options.language='en'] - Language code. English('en') and Korean('ko') are provided as default. To use the other languages, use {@link DatePicker#localeTexts DatePicker.localeTexts}.
  *     @param {object|boolean} [options.timePicker] - [TimePicker](https://nhn.github.io/tui.time-picker/latest) options. Refer to the [TimePicker instance's options](https://nhn.github.io/tui.time-picker/latest/TimePicker). To create the TimePicker without customization, set to true.
@@ -54,11 +56,13 @@ var CLASS_NAME_SELECTED_RANGE = 'tui-is-selected-range';
  *     startpicker: {
  *         input: '#start-input',
  *         container: '#start-container'
- *         date: new Date(2019, 3, 1)
+ *         date: new Date(2019, 3, 1),
+ *         weekStart: 1,
  *     },
  *     endpicker: {
  *         input: '#end-input',
- *         container: '#end-container'
+ *         container: '#end-container',
+ *         weekStart: 1,
  *     },
  *     type: 'date',
  *     format: 'yyyy-MM-dd'
@@ -118,14 +122,16 @@ var DateRangePicker = defineClass(
           element: startInput,
           format: options.format
         },
-        date: options.startpicker.date
+        date: options.startpicker.date,
+        weekStart: options.startpicker.weekStart || 0
       });
       var endpickerOpt = extend({}, options, {
         input: {
           element: endInput,
           format: options.format
         },
-        date: options.endpicker.date
+        date: options.endpicker.date,
+        weekStart: options.endpicker.weekStart || 0
       });
 
       this._startpicker = new DatePicker(startpickerContainer, startpickerOpt);

--- a/src/js/dateRangePicker/index.js
+++ b/src/js/dateRangePicker/index.js
@@ -32,12 +32,12 @@ var CLASS_NAME_SELECTED_RANGE = 'tui-is-selected-range';
  *         @param {HTMLElement|string} options.startpicker.input - Startpicker input element or selector
  *         @param {HTMLElement|string} options.startpicker.container - Startpicker container element or selector
  *         @param {Date|number} [options.startpicker.date] - Initial date of the start picker. Set by a Date instance or a number(timestamp). (default: no initial date)
- *         @param {number} [options.startpicker.weekStart = 0] - start picker's day of the week start. 0 (Sunday) to 6 (Saturday) (default: 0(start on Sunday))
+ *         @param {string} [options.startpicker.weekStartDay = 'Sun'] - Start of the week. 'Sun', 'Mon', ..., 'Sat'(default: 'Sun'(start on Sunday))
  *     @param {object} options.endpicker - Endpicker options
  *         @param {HTMLElement|string} options.endpicker.input - Endpicker input element or selector
  *         @param {HTMLElement|string} options.endpicker.container - Endpicker container element or selector
  *         @param {Date|number} [options.endpicker.date] - Initial date of the end picker. Set by a Date instance or a number(timestamp). (default: no initial date)
- *         @param {number} [options.endpicker.weekStart = 0] - end picker's day of the week start. 0 (Sunday) to 6 (Saturday) (default: 0(start on Sunday))
+ *         @param {string} [options.endpicker.weekStartDay = 'Sun'] - Start of the week. 'Sun', 'Mon', ..., 'Sat'(default: 'Sun'(start on Sunday))
  *     @param {('date'|'month'|'year')} [options.type = 'date'] - DatePicker type. Determine whether to choose a date, month, or year.
  *     @param {string} [options.language='en'] - Language code. English('en') and Korean('ko') are provided as default. To use the other languages, use {@link DatePicker#localeTexts DatePicker.localeTexts}.
  *     @param {object|boolean} [options.timePicker] - [TimePicker](https://nhn.github.io/tui.time-picker/latest) options. Refer to the [TimePicker instance's options](https://nhn.github.io/tui.time-picker/latest/TimePicker). To create the TimePicker without customization, set to true.
@@ -57,12 +57,12 @@ var CLASS_NAME_SELECTED_RANGE = 'tui-is-selected-range';
  *         input: '#start-input',
  *         container: '#start-container'
  *         date: new Date(2019, 3, 1),
- *         weekStart: 1,
+ *         weekStartDay: 'Mon',
  *     },
  *     endpicker: {
  *         input: '#end-input',
  *         container: '#end-container',
- *         weekStart: 1,
+ *         weekStartDay: 'Mon',
  *     },
  *     type: 'date',
  *     format: 'yyyy-MM-dd'
@@ -123,7 +123,7 @@ var DateRangePicker = defineClass(
           format: options.format
         },
         date: options.startpicker.date,
-        weekStart: options.startpicker.weekStart || 0
+        weekStartDay: options.startpicker.weekStartDay || 'Sun'
       });
       var endpickerOpt = extend({}, options, {
         input: {
@@ -131,7 +131,7 @@ var DateRangePicker = defineClass(
           format: options.format
         },
         date: options.endpicker.date,
-        weekStart: options.endpicker.weekStart || 0
+        weekStartDay: options.endpicker.weekStartDay || 'Sun'
       });
 
       this._startpicker = new DatePicker(startpickerContainer, startpickerOpt);

--- a/src/js/dateRangePicker/index.js
+++ b/src/js/dateRangePicker/index.js
@@ -123,7 +123,7 @@ var DateRangePicker = defineClass(
           format: options.format
         },
         date: options.startpicker.date,
-        weekStartDay: options.startpicker.weekStartDay || 'Sun'
+        weekStartDay: options.startpicker.weekStartDay
       });
       var endpickerOpt = extend({}, options, {
         input: {
@@ -131,7 +131,7 @@ var DateRangePicker = defineClass(
           format: options.format
         },
         date: options.endpicker.date,
-        weekStartDay: options.endpicker.weekStartDay || 'Sun'
+        weekStartDay: options.endpicker.weekStartDay
       });
 
       this._startpicker = new DatePicker(startpickerContainer, startpickerOpt);

--- a/src/js/datepicker/index.js
+++ b/src/js/datepicker/index.js
@@ -33,6 +33,7 @@ var mouseTouchEvent = require('../mouseTouchEvent');
 var tmpl = require('../../template/datepicker/index');
 var DatePickerInput = require('./input');
 
+var DEFAULT_WEEK_START_DAY = constants.DEFAULT_WEEK_START_DAY;
 var DEFAULT_LANGUAGE_TYPE = constants.DEFAULT_LANGUAGE_TYPE;
 var TYPE_DATE = constants.TYPE_DATE;
 var TYPE_MONTH = constants.TYPE_MONTH;
@@ -79,7 +80,7 @@ var mergeDefaultOption = function(option) {
       openers: [],
       autoClose: true,
       usageStatistics: true,
-      weekStartDay: 'Sun'
+      weekStartDay: DEFAULT_WEEK_START_DAY
     },
     option
   );

--- a/src/js/datepicker/index.js
+++ b/src/js/datepicker/index.js
@@ -79,7 +79,7 @@ var mergeDefaultOption = function(option) {
       openers: [],
       autoClose: true,
       usageStatistics: true,
-      weekStart: 0
+      weekStartDay: 'Sun'
     },
     option
   );
@@ -129,7 +129,7 @@ var mergeDefaultOption = function(option) {
  *      @param {boolean} [options.showAlways = false] - Show the DatePicker always
  *      @param {boolean} [options.autoClose = true] - Close the DatePicker after clicking the date
  *      @param {boolean} [options.usageStatistics = true] - Send a hostname to Google Analytics (default: true)
- *      @param {boolean} [options.weekStart = 0] - Day of the week start. 0 (Sunday) to 6 (Saturday) (default: 0(start on Sunday))
+ *      @param {string} [options.weekStartDay = 'Sun'] - Start of the week. 'Sun', 'Mon', ..., 'Sat'(default: 'Sun'(start on Sunday))
  * @example
  * import DatePicker from 'tui-date-picker' // ES6
  * // const DatePicker = require('tui-date-picker'); // CommonJS
@@ -165,7 +165,7 @@ var mergeDefaultOption = function(option) {
  *     date: new Date(2015, 0, 1)
  *     selectableRanges: [range1, range2],
  *     openers: ['#opener'],
- *     weekStart: 1,
+ *     weekStartDay: 'Mon',
  * });
  */
 var DatePicker = defineClass(
@@ -241,7 +241,7 @@ var DatePicker = defineClass(
         this._element.querySelector(SELECTOR_CALENDAR_CONTAINER),
         extend(options.calendar, {
           usageStatistics: options.usageStatistics,
-          weekStart: options.weekStart
+          weekStartDay: options.weekStartDay
         })
       );
 

--- a/src/js/datepicker/index.js
+++ b/src/js/datepicker/index.js
@@ -78,7 +78,8 @@ var mergeDefaultOption = function(option) {
       selectableRanges: null,
       openers: [],
       autoClose: true,
-      usageStatistics: true
+      usageStatistics: true,
+      weekStart: 0
     },
     option
   );
@@ -128,6 +129,7 @@ var mergeDefaultOption = function(option) {
  *      @param {boolean} [options.showAlways = false] - Show the DatePicker always
  *      @param {boolean} [options.autoClose = true] - Close the DatePicker after clicking the date
  *      @param {boolean} [options.usageStatistics = true] - Send a hostname to Google Analytics (default: true)
+ *      @param {boolean} [options.weekStart = 0] - Day of the week start. 0 (Sunday) to 6 (Saturday) (default: 0(start on Sunday))
  * @example
  * import DatePicker from 'tui-date-picker' // ES6
  * // const DatePicker = require('tui-date-picker'); // CommonJS
@@ -162,7 +164,8 @@ var mergeDefaultOption = function(option) {
  *     type: 'date',
  *     date: new Date(2015, 0, 1)
  *     selectableRanges: [range1, range2],
- *     openers: ['#opener']
+ *     openers: ['#opener'],
+ *     weekStart: 1,
  * });
  */
 var DatePicker = defineClass(
@@ -237,7 +240,8 @@ var DatePicker = defineClass(
       this._calendar = new Calendar(
         this._element.querySelector(SELECTOR_CALENDAR_CONTAINER),
         extend(options.calendar, {
-          usageStatistics: options.usageStatistics
+          usageStatistics: options.usageStatistics,
+          weekStart: options.weekStart
         })
       );
 

--- a/test/calendar/body.spec.js
+++ b/test/calendar/body.spec.js
@@ -50,13 +50,4 @@ describe('Calendar - Body', function() {
 
     expect(dateElements.length).toBe(12);
   });
-
-  it('should change start day of week', function() {
-    ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].forEach(function(day, index) {
-      body.destroy();
-      body = new Body(container, { language: 'en', weekStart: index });
-
-      expect(body._dateLayer._makeContext().Sun).toBe(day);
-    });
-  });
 });

--- a/test/calendar/body.spec.js
+++ b/test/calendar/body.spec.js
@@ -50,4 +50,13 @@ describe('Calendar - Body', function() {
 
     expect(dateElements.length).toBe(12);
   });
+
+  it('should change start day of week', function() {
+    ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].forEach(function(day, index) {
+      body.destroy();
+      body = new Body(container, { language: 'en', weekStart: index });
+
+      expect(body._dateLayer._makeContext().Sun).toBe(day);
+    });
+  });
 });

--- a/test/calendar/dateLayer.spec.js
+++ b/test/calendar/dateLayer.spec.js
@@ -1,0 +1,25 @@
+/**
+ * @fileoverview Calendar date layer spec
+ * @author NHN. FE Development Lab <dl_javascript@nhn.com>
+ */
+'use strict';
+
+var DateLayer = require('../../src/js/calendar/layerBody/date');
+
+describe('Calendar - date layer', function() {
+  var dateLayer;
+
+  it('should have a default value of 0', function() {
+    dateLayer = new DateLayer('en');
+
+    expect(dateLayer.weekStartDay).toBe(0);
+  });
+
+  it('should change start day of week', function() {
+    ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].forEach(function(day, index) {
+      dateLayer = new DateLayer('en', day);
+
+      expect(dateLayer.weekStartDay).toBe(index);
+    });
+  });
+});


### PR DESCRIPTION
* 한 주의 시작을 일요일이 아닌 요일로 지정할 수 있는 옵션 `weekStartDay`을 추가하였습니다.
  * 'Sun'(default), 'Mon', 'Tue', ..., 'Sat'

* AS-IS (일요일 시작 고정)
  * ![스크린샷 2021-03-04 오후 4 45 14](https://user-images.githubusercontent.com/28647773/109928637-ff37f600-7d08-11eb-9a52-d12f6f1009be.png)
* TO-BE (월요일 시작 (weekStartDay: 'Mon'))
  * ![스크린샷 2021-03-04 오후 4 45 56](https://user-images.githubusercontent.com/28647773/109928739-1a0a6a80-7d09-11eb-92a3-12e9e6249bd2.png)
* TO-BE (화요일 시작 (weekStartDay: 'Tue'))
  * ![스크린샷 2021-03-08 오후 4 45 35](https://user-images.githubusercontent.com/28647773/110290107-b72d1200-802d-11eb-892b-c612dfff52fd.png)
* etc..
