### PR TITLE
fix: fix opening selection of month and year when datepicker is used …

### DIFF
--- a/src/js/calendar/header.js
+++ b/src/js/calendar/header.js
@@ -137,10 +137,16 @@ var Header = defineClass(
      * @param {Event} ev An event object
      * @private
      */
-    _onClickHandler: function(ev) {
+     _onClickHandler: function(ev) {
       var target = util.getTarget(ev);
 
-      if (closest(target, SELECTOR_BTN)) {
+      let isClosestBtn  = false;
+      try {
+        isClosestBtn = closest(target, SELECTOR_BTN)
+      } catch(error) {
+
+      }
+      if (isClosestBtn) {
         this.fire('click', ev);
       }
     },

--- a/src/js/datepicker/index.js
+++ b/src/js/datepicker/index.js
@@ -645,19 +645,37 @@ var DatePicker = defineClass(
      * @param {Event} ev An event object
      * @private
      */
-    _onClickHandler: function(ev) {
+     _onClickHandler: function(ev) {      
       var target = util.getTarget(ev);
       ev.preventDefault();
+      let isCLosesClassName = false;
+      let isCLosestSelectorCalendarTitle = false;
+      let isClosestSelectorButton = false;
+      try {
+        isCLosesClassName = closest(target, '.' + CLASS_NAME_SELECTABLE);
+      } catch(error) {
+       console.log(error);
+      }
+      try {
+        isCLosestSelectorCalendarTitle = closest(target, SELECTOR_CALENDAR_TITLE);
+      } catch (error) {
+        console.log(error);
+        
+      }
+      try {
+        isClosestSelectorButton = closest(target, '.' + CLASS_NAME_SELECTOR_BUTTON)
+      } catch(error) {
+        console.log(error);
 
-      if (closest(target, '.' + CLASS_NAME_SELECTABLE)) {
+      }
+      if (isCLosesClassName) {
         this._updateDate(target);
-      } else if (closest(target, SELECTOR_CALENDAR_TITLE)) {
+      } else if (isCLosestSelectorCalendarTitle) {
         this.drawUpperCalendar(this._date);
-      } else if (closest(target, '.' + CLASS_NAME_SELECTOR_BUTTON)) {
+      } else if (isClosestSelectorButton) {
         this._changePicker(target);
       }
     },
-
     /**
      * Update date from event-target
      * @param {HTMLElement} target An event target element


### PR DESCRIPTION
…in shadow dom (fix #81)

This issue can be fixed in the subcomponent of the date-picker tui-code-snippet. The issue happens because of the shadow dom and because of it it is not possible to use the date picker with web components.