### PR TITLE
fix: prev or next year button doesn't appear even though there are selectable years

### DIFF
--- a/src/js/calendar/index.js
+++ b/src/js/calendar/index.js
@@ -418,7 +418,7 @@ var Calendar = defineClass(
         case TYPE_MONTH:
           return this._getRelativeDate(12); // 12 months = 1 year
         case TYPE_YEAR:
-          return this._getRelativeDate(108); // 108 months = 9 years = 12 * 9
+          return this._getRelativeDate(60); // 60 months = 5 years = 12 * 5
         default:
           throw new Error('Unknown layer type');
       }
@@ -434,7 +434,7 @@ var Calendar = defineClass(
         case TYPE_MONTH:
           return this._getRelativeDate(-12); // 12 months = 1 year
         case TYPE_YEAR:
-          return this._getRelativeDate(-108); // 108 months = 9 years = 12 * 9
+          return this._getRelativeDate(-60); // 60 months = 5 years = 12 * 5
         default:
           throw new Error('Unknown layer type');
       }

--- a/src/js/calendar/index.js
+++ b/src/js/calendar/index.js
@@ -410,15 +410,21 @@ var Calendar = defineClass(
 
     /**
      * Return the date a year later.
+     * @param {boolean} useCustomStep - flag for getting relative date by using custom step
+     * @param {number} step - custom step for getting relative date
      * @returns {Date}
      */
-    getNextYearDate: function() {
+    getNextYearDate: function(useCustomStep, step) {
+      if (useCustomStep && step) {
+        return this._getRelativeDate(step);
+      }
+
       switch (this.getType()) {
         case TYPE_DATE:
         case TYPE_MONTH:
           return this._getRelativeDate(12); // 12 months = 1 year
         case TYPE_YEAR:
-          return this._getRelativeDate(60); // 60 months = 5 years = 12 * 5
+          return this._getRelativeDate(108); // 108 months = 9 years = 12 * 9
         default:
           throw new Error('Unknown layer type');
       }
@@ -426,15 +432,21 @@ var Calendar = defineClass(
 
     /**
      * Return the date a year previously.
+     * @param {boolean} useCustomStep - flag for getting relative date by using custom step
+     * @param {number} step - custom step for getting relative date
      * @returns {Date}
      */
-    getPrevYearDate: function() {
+    getPrevYearDate: function(useCustomStep, step) {
+      if (useCustomStep && step) {
+        return this._getRelativeDate(step);
+      }
+
       switch (this.getType()) {
         case TYPE_DATE:
         case TYPE_MONTH:
           return this._getRelativeDate(-12); // 12 months = 1 year
         case TYPE_YEAR:
-          return this._getRelativeDate(-60); // 60 months = 5 years = 12 * 5
+          return this._getRelativeDate(-108); // 108 months = 9 years = 12 * 9
         default:
           throw new Error('Unknown layer type');
       }

--- a/src/js/calendar/index.js
+++ b/src/js/calendar/index.js
@@ -410,13 +410,12 @@ var Calendar = defineClass(
 
     /**
      * Return the date a year later.
-     * @param {boolean} useCustomStep - flag for getting relative date by using custom step
-     * @param {number} step - custom step for getting relative date
+     * @param {number} [customStep] - custom step for getting relative date
      * @returns {Date}
      */
-    getNextYearDate: function(useCustomStep, step) {
-      if (useCustomStep && step) {
-        return this._getRelativeDate(step);
+    getNextYearDate: function(customStep) {
+      if (customStep) {
+        return this._getRelativeDate(customStep);
       }
 
       switch (this.getType()) {
@@ -432,13 +431,12 @@ var Calendar = defineClass(
 
     /**
      * Return the date a year previously.
-     * @param {boolean} useCustomStep - flag for getting relative date by using custom step
-     * @param {number} step - custom step for getting relative date
+     * @param {number} [customStep] - custom step for getting relative date
      * @returns {Date}
      */
-    getPrevYearDate: function(useCustomStep, step) {
-      if (useCustomStep && step) {
-        return this._getRelativeDate(step);
+    getPrevYearDate: function(customStep) {
+      if (customStep) {
+        return this._getRelativeDate(customStep);
       }
 
       switch (this.getType()) {

--- a/src/js/datepicker/index.js
+++ b/src/js/datepicker/index.js
@@ -744,8 +744,10 @@ var DatePicker = defineClass(
      * @private
      */
     _setDisplayHeadButtons: function() {
-      var nextYearDate = this._calendar.getNextYearDate();
-      var prevYearDate = this._calendar.getPrevYearDate();
+      var isYearCalendar = this.getCalendarType() === TYPE_YEAR;
+      var customStep = 60; // 60 months = 5 years = 12 * 5
+      var nextYearDate = this._calendar.getNextYearDate(isYearCalendar, customStep);
+      var prevYearDate = this._calendar.getPrevYearDate(isYearCalendar, -customStep);
       var maxTimestamp = this._rangeModel.getMaximumValue();
       var minTimestamp = this._rangeModel.getMinimumValue();
       var nextYearBtn = this._element.querySelector('.' + CLASS_NAME_NEXT_YEAR_BTN);

--- a/src/js/datepicker/index.js
+++ b/src/js/datepicker/index.js
@@ -744,10 +744,13 @@ var DatePicker = defineClass(
      * @private
      */
     _setDisplayHeadButtons: function() {
-      var isYearCalendar = this.getCalendarType() === TYPE_YEAR;
       var customStep = 60; // 60 months = 5 years = 12 * 5
-      var nextYearDate = this._calendar.getNextYearDate(isYearCalendar, customStep);
-      var prevYearDate = this._calendar.getPrevYearDate(isYearCalendar, -customStep);
+      var nextYearDate = this._calendar.getNextYearDate(
+        this.getCalendarType() === TYPE_YEAR ? customStep : null
+      );
+      var prevYearDate = this._calendar.getPrevYearDate(
+        this.getCalendarType() === TYPE_YEAR ? -customStep : null
+      );
       var maxTimestamp = this._rangeModel.getMaximumValue();
       var minTimestamp = this._rangeModel.getMinimumValue();
       var nextYearBtn = this._element.querySelector('.' + CLASS_NAME_NEXT_YEAR_BTN);

--- a/test/calendar/calendar.spec.js
+++ b/test/calendar/calendar.spec.js
@@ -48,7 +48,7 @@ describe('Calendar', function() {
 
       // year calendar
       expect(calendar.getNextDate()).toEqual(
-        new Date(currentDate.getFullYear() + 5, currentDate.getMonth())
+        new Date(currentDate.getFullYear() + 9, currentDate.getMonth())
       );
     });
 
@@ -75,7 +75,7 @@ describe('Calendar', function() {
 
       // year calendar
       expect(calendar.getPrevDate()).toEqual(
-        new Date(currentDate.getFullYear() - 5, currentDate.getMonth())
+        new Date(currentDate.getFullYear() - 9, currentDate.getMonth())
       );
     });
 
@@ -140,7 +140,7 @@ describe('Calendar', function() {
       });
       calendar.drawNext();
 
-      expect(calendar.getDate().getFullYear()).toBe(2021);
+      expect(calendar.getDate().getFullYear()).toBe(2025);
       expect(calendar.getDate().getMonth()).toBe(0);
     });
 
@@ -169,7 +169,7 @@ describe('Calendar', function() {
       });
       calendar.drawPrev();
 
-      expect(calendar.getDate().getFullYear()).toBe(2011);
+      expect(calendar.getDate().getFullYear()).toBe(2007);
       expect(calendar.getDate().getMonth()).toBe(0);
     });
 

--- a/test/calendar/calendar.spec.js
+++ b/test/calendar/calendar.spec.js
@@ -48,7 +48,7 @@ describe('Calendar', function() {
 
       // year calendar
       expect(calendar.getNextDate()).toEqual(
-        new Date(currentDate.getFullYear() + 9, currentDate.getMonth())
+        new Date(currentDate.getFullYear() + 5, currentDate.getMonth())
       );
     });
 
@@ -75,7 +75,7 @@ describe('Calendar', function() {
 
       // year calendar
       expect(calendar.getPrevDate()).toEqual(
-        new Date(currentDate.getFullYear() - 9, currentDate.getMonth())
+        new Date(currentDate.getFullYear() - 5, currentDate.getMonth())
       );
     });
 
@@ -140,7 +140,7 @@ describe('Calendar', function() {
       });
       calendar.drawNext();
 
-      expect(calendar.getDate().getFullYear()).toBe(2025);
+      expect(calendar.getDate().getFullYear()).toBe(2021);
       expect(calendar.getDate().getMonth()).toBe(0);
     });
 
@@ -169,7 +169,7 @@ describe('Calendar', function() {
       });
       calendar.drawPrev();
 
-      expect(calendar.getDate().getFullYear()).toBe(2007);
+      expect(calendar.getDate().getFullYear()).toBe(2011);
       expect(calendar.getDate().getMonth()).toBe(0);
     });
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

- Fixed an issue that the previous or next year buttons would not appear even though there were selectable years.
  - If you look at the picture below, in the past, the previous/next page buttons appeared only when you could select before 2013/after 2031.
  - However, even if it was selectable from 2014 to 2017 and 2027 to 2030, the previous/next page buttons did not appear.
  - This criterion has been changed to whether the year closest to the current one can be selected, rather than whether the year in the middle of the previous/next page can be selected.
  - So if there is even one selectable year on the previous/next page, the button appears.

![image](https://user-images.githubusercontent.com/41339744/203009778-0b244dc0-63da-49ae-979e-ffe7cdd3e75f.png)



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
