### PR TITLE
fix: set incorrect time range on end date picker

### DIFF
--- a/src/js/dateRangePicker/index.js
+++ b/src/js/dateRangePicker/index.js
@@ -302,12 +302,29 @@ var DateRangePicker = defineClass(
       this.fire('change:end');
     },
 
+    /*
+     * Get date of start picker and end picker being same
+     * @returns {boolean}
+     * @private
+     */
+    _isStartAndEndDateSame: function() {
+      return (
+        !!this._endpicker.getDate() &&
+        !!this._startpicker.getDate() &&
+        dateUtil.compare(
+          this._endpicker.getDate(),
+          this._startpicker.getDate(),
+          constants.TYPE_DATE
+        ) === 0
+      );
+    },
+
     /**
      * Set time range on end picker
      * @private
      */
     _setTimeRangeOnEndPicker: function() {
-      var pickerDate, timeRange;
+      var pickerDate, timeRange, timeRangeToSet;
       var endTimePicker = this._endpicker._timePicker;
 
       if (!endTimePicker) {
@@ -316,9 +333,10 @@ var DateRangePicker = defineClass(
 
       pickerDate = this._endpicker.getDate() || this._startpicker.getDate();
       timeRange = this._getTimeRangeFromStartPicker();
+      timeRangeToSet = pickerDate && timeRange[pickerDate.getDate()];
 
-      if (pickerDate && timeRange[pickerDate.getDate()]) {
-        endTimePicker.setRange(timeRange[pickerDate.getDate()]);
+      if (this._isStartAndEndDateSame() && timeRangeToSet) {
+        endTimePicker.setRange(timeRangeToSet);
         this._isRangeSet = true;
       } else if (this._isRangeSet) {
         endTimePicker.setRange({ hour: 0, minute: 0 });

--- a/test/dateRangePicker/dateRangePicker.spec.js
+++ b/test/dateRangePicker/dateRangePicker.spec.js
@@ -171,6 +171,36 @@ describe('DateRangePicker', function() {
     expect(minuteSelectOptions).toMatchObject(expectMatchArray);
   });
 
+  it('should not set disabled when date of start picker does not same as date of endPicker for time select options in endPicker', function() {
+    var startPickerDate = new Date(2021, 1, 1, 9, 30);
+    var endPickerDate = new Date(2022, 1, 1, 9, 30);
+    var hourSelectOptions, minuteSelectOptions;
+
+    picker = new DateRangePicker({
+      startpicker: {
+        date: startPickerDate,
+        input: startpickerInput,
+        container: startpickerContainer
+      },
+      endpicker: {
+        date: endPickerDate,
+        input: endpickerInput,
+        container: endpickerContainer
+      },
+      timePicker: true
+    });
+
+    hourSelectOptions = Array.from(
+      endpickerContainer.querySelectorAll('.tui-timepicker-hour option')
+    );
+    minuteSelectOptions = Array.from(
+      endpickerContainer.querySelectorAll('.tui-timepicker-minute option')
+    );
+
+    expect(hourSelectOptions).toMatchObject(getMatchedArray(12, 0));
+    expect(minuteSelectOptions).toMatchObject(getMatchedArray(60, 0));
+  });
+
   it('should disable endpicker with null when initial start-date is null', function() {
     picker = new DateRangePicker({
       startpicker: {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Fixed that the selectable time range was set for endPicker if the startPicker and endPicker had the same day even if the year and month were different.
  * It was caused by setting a time range without comparing startPicker's date to endPicker's date.

**As-Is**
![](https://user-images.githubusercontent.com/41339744/203256804-6371273d-7472-46a0-a8ef-a308f976f9a8.gif)

**To-Be**
![](https://user-images.githubusercontent.com/41339744/203257172-82354f07-f332-4624-80b5-b91478069618.gif)



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
