### PR TITLE
fix: fire change event redundantly when time also changed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13214,9 +13214,9 @@
       "dev": true
     },
     "tui-time-picker": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tui-time-picker/-/tui-time-picker-2.1.3.tgz",
-      "integrity": "sha512-EjOOaS+NqTSuBbsR+gEsNytyd6Mtw+JvwaIsFc6iytJi+Ncm7yQMhZE7T8CjLrFEhPFluuma10WgU8WIxJrsbQ=="
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tui-time-picker/-/tui-time-picker-2.1.5.tgz",
+      "integrity": "sha512-A0JzWpVIaTun8m4BEGa/COVKRk3m+FyBdC6s8xJ0mPToloBqkQ1SRC2Gd/GDZHhxKAdlDoLCfgCselK0oN5Ykw=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "webpack-dev-server": "^3.8.0"
   },
   "dependencies": {
-    "tui-time-picker": "^2.1.3"
+    "tui-time-picker": "^2.1.5"
   }
 }

--- a/src/js/datepicker/index.js
+++ b/src/js/datepicker/index.js
@@ -1155,7 +1155,7 @@ var DatePicker = defineClass(
         this._date = newDate;
         this._calendar.draw({ date: newDate });
         if (this._timePicker) {
-          this._timePicker.setTime(newDate.getHours(), newDate.getMinutes());
+          this._timePicker.setTime(newDate.getHours(), newDate.getMinutes(), true);
         }
         this._syncToInput();
 

--- a/src/js/datepicker/index.js
+++ b/src/js/datepicker/index.js
@@ -1133,11 +1133,12 @@ var DatePicker = defineClass(
     /**
      * Select the date.
      * @param {Date|number} date - Date instance or timestamp to set
+     * @param {boolean} [silent] - Prevents firing 'change' event if it is true.
      * @example
      * datepicker.setDate(new Date()); // Set today
      */
     // eslint-disable-next-line complexity
-    setDate: function(date) {
+    setDate: function(date, silent) {
       var isValidInput, newDate, shouldUpdate;
 
       if (date === null) {
@@ -1174,7 +1175,9 @@ var DatePicker = defineClass(
          * // unbind the 'change' event
          * datepicker.off('change');
          */
-        this.fire('change');
+        if (!silent) {
+          this.fire('change');
+        }
       }
     },
 

--- a/test/datepicker/datepicker.spec.js
+++ b/test/datepicker/datepicker.spec.js
@@ -152,6 +152,15 @@ describe('Date Picker', function() {
 
         expect(spy).toHaveBeenCalledTimes(1);
       });
+
+      it('should not fire change event when silent is true', function() {
+        var spy = jest.fn();
+        datepicker.on('change', spy);
+
+        datepicker.setDate(new Date(2017, 10, 27, 23, 59), true);
+
+        expect(spy).toHaveBeenCalledTimes(0);
+      });
     });
 
     it('setType', function() {

--- a/test/datepicker/datepicker.spec.js
+++ b/test/datepicker/datepicker.spec.js
@@ -1,3 +1,5 @@
+/* eslint-disable max-nested-callbacks */
+
 /**
  * @fileoverview DatePicker spec
  */
@@ -131,14 +133,25 @@ describe('Date Picker', function() {
       expect(datepicker.getCalendar()).toEqual(expect.any(Calendar));
     });
 
-    it('setDate', function() {
-      datepicker.setDate(new Date(2017, 2, 12));
+    describe('setDate', function() {
+      it('default', function() {
+        datepicker.setDate(new Date(2017, 2, 12));
 
-      expect(datepicker.getDate()).toEqual(new Date(2017, 2, 12));
+        expect(datepicker.getDate()).toEqual(new Date(2017, 2, 12));
 
-      datepicker.setDate();
+        datepicker.setDate();
 
-      expect(datepicker.getDate()).toEqual(new Date(2017, 2, 12));
+        expect(datepicker.getDate()).toEqual(new Date(2017, 2, 12));
+      });
+
+      it('should firing change event only once', function() {
+        var spy = jest.fn();
+        datepicker.on('change', spy);
+
+        datepicker.setDate(new Date(2022, 11, 23, 23, 59));
+
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
     });
 
     it('setType', function() {

--- a/test/datepicker/datepicker.spec.js
+++ b/test/datepicker/datepicker.spec.js
@@ -148,7 +148,7 @@ describe('Date Picker', function() {
         var spy = jest.fn();
         datepicker.on('change', spy);
 
-        datepicker.setDate(new Date(2022, 11, 23, 23, 59));
+        datepicker.setDate(new Date(2017, 10, 27, 23, 59));
 
         expect(spy).toHaveBeenCalledTimes(1);
       });


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Fixed that the change event would occur redundantly if the time of day was also changed when calling the `setDate` API.
  * This is fixed by setting the `silent` option of the `setTime` API added in [TOAST UI TimePicker v2.1.5](https://github.com/nhn/tui.time-picker/releases/tag/v2.1.5) to true.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
